### PR TITLE
Fix EPUB content route and add ARM64 image publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,9 @@
-name: Build and publish Docker image
+name: Build and publish ARM64 Docker image
 
 on:
   push:
     branches:
-      - dev
-      - main
       - raspberry-pi-arm64-support
-    tags:
-      - "v*"
   workflow_dispatch:
 
 permissions:
@@ -18,8 +14,8 @@ env:
   IMAGE_NAME: ghcr.io/skyeblu7/homebranch-api
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
+  docker-arm64:
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Check out repository
@@ -35,12 +31,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push multi-arch image
+      - name: Build and push ARM64 image
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           tags: |
-            ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:arm64
+            ${{ env.IMAGE_NAME }}:raspberry-pi
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+      - raspberry-pi-arm64-support
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/skyeblu7/homebranch-api
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/src/presentation/controllers/book.controller.ts
+++ b/src/presentation/controllers/book.controller.ts
@@ -314,7 +314,7 @@ export class BookController {
     return result.value;
   }
 
-  @Get(':id/content/*')
+  @Get(':id/content/*entryPath')
   @UseGuards(JwtAuthGuard)
   async getBookContent(
     @Param('id') id: string,
@@ -325,6 +325,7 @@ export class BookController {
     // Extract the entry path from the URL, after /content/
     const rawPath = req.url.split(`/content/`)[1]?.split('?')[0] ?? '';
     const entryPath = rawPath.split('/').map(decodeURIComponent).join('/');
+
 
     const result = await this.getBookContentUseCase.execute({ id, entryPath, format: query.format });
 


### PR DESCRIPTION
This PR adds Raspberry Pi / ARM64 support for the API image and fixes EPUB resource loading.

Changes:
- Adds a GitHub Actions workflow that builds and publishes a linux/arm64 Docker image to GHCR.
- Fixes the EPUB content route wildcard handling by using a named wildcard parameter.
- Allows nested EPUB resource paths such as XHTML, CSS, and image files to be served correctly.

Tested:
- Built and published ARM64 API image successfully.
- Verified the image pulls on Raspberry Pi / ARM64.
- Verified EPUB content resources load correctly through the API route.